### PR TITLE
Update dependencies

### DIFF
--- a/mqtt-client.opam
+++ b/mqtt-client.opam
@@ -12,7 +12,7 @@ depends: [
   "lwt"
   "lwt_ppx"
   "tls"
-  "dune" {build}
+  "dune" {>= "2.8.0"}
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/mqtt-client.opam
+++ b/mqtt-client.opam
@@ -10,6 +10,7 @@ tags: ["telemetry" "mqtt" "network" "protocol"]
 depends: [
   "ocplib-endian" {>= "0.6"}
   "logs"
+  "fmt"
   "lwt"
   "lwt_ppx"
   "tls"

--- a/mqtt-client.opam
+++ b/mqtt-client.opam
@@ -9,6 +9,7 @@ dev-repo: "git://github.com/odis-labs/ocaml-mqtt"
 tags: ["telemetry" "mqtt" "network" "protocol"]
 depends: [
   "ocplib-endian" {>= "0.6"}
+  "logs"
   "lwt"
   "lwt_ppx"
   "tls"

--- a/mqtt-client.opam
+++ b/mqtt-client.opam
@@ -10,7 +10,7 @@ tags: ["telemetry" "mqtt" "network" "protocol"]
 depends: [
   "ocplib-endian" {>= "0.6"}
   "logs"
-  "fmt"
+  "fmt" {>= "0.8.7"}
   "lwt"
   "lwt_ppx"
   "tls"

--- a/mqtt-client/dune
+++ b/mqtt-client/dune
@@ -3,4 +3,4 @@
  (public_name mqtt-client)
  (preprocess
   (pps lwt_ppx))
- (libraries lwt lwt.unix logs logs.lwt tls tls.lwt ocplib-endian))
+ (libraries fmt lwt lwt.unix logs logs.lwt tls tls.lwt ocplib-endian))


### PR DESCRIPTION
Update the needed version of dune to `2.8.0` as specified in the `dune-project` file
Add logs to the dependencies
Add fmt to the dependencies and set a lowerbound to `0.8.7` (due to `Fmt.Dump.String` not existing before)