### PR TITLE
Partly upgrade to 3.1.1

### DIFF
--- a/mqtt-client/Mqtt_client.ml
+++ b/mqtt-client/Mqtt_client.ml
@@ -325,7 +325,7 @@ let subscribe ?(dup = false) ?(qos = Mqtt_core.Atleast_once) ?(retain = false)
   let subscribe_packet =
     Mqtt_packet.Encoder.subscribe ~dup ~qos ~retain ~id:pkt_id topics
   in
-  let qos_list = List.map (fun (_, q) -> q) topics in
+  let qos_list = List.map (fun (_, q) -> Ok q) topics in
   let cond = Lwt_condition.create () in
   Hashtbl.add client.inflight pkt_id (cond, Suback (pkt_id, qos_list));
   wrap_catch client (fun () ->

--- a/mqtt-client/Mqtt_client.mli
+++ b/mqtt-client/Mqtt_client.mli
@@ -12,6 +12,12 @@ type t
     {{!val:Mqtt_client.connect} connection options} for more information. *)
 type credentials = Credentials of string * string | Username of string
 
+(** Client error & exceptions
+
+    Defines the exceptions raised by the client *)
+
+exception Connection_error
+
 (** Quality of Service level.
 
     Defines the guarantee of delivery for messages. *)

--- a/mqtt-client/Mqtt_packet.ml
+++ b/mqtt-client/Mqtt_packet.ml
@@ -141,7 +141,7 @@ let qos_of_bits = function
   | 2 -> Exactly_once
   | b -> raise (Invalid_argument ("invalid qos number: " ^ string_of_int b))
 
-let suback_qos_of_bits = function 128 -> Error () | b -> Ok (qos_of_bits b)
+let suback_qos_of_bits = function 0x80 -> Error () | b -> Ok (qos_of_bits b)
 let bit_of_bool = function true -> 1 | false -> 0
 
 let bool_of_bit = function


### PR DESCRIPTION
This pull request aims to implement most of the differences between mqtt-3.1.0 and mqtt-3.1.1.
The differences can be found [here](https://github.com/mqtt/mqtt.org/wiki/Differences-between-3.1.0-and-3.1.1)

Out of them all, are implemented in this PR:
- Protocol name has changed to MQTT & Protocol level has changed to 0x04
- Ensure that DUP isn't set for QoS 0
- SUBACK can now indicate failure

Due to the way the acknowledge packets are currently handled however, the third point will need to be reviewed on the client side as subscription failure will be treated as unexpected ACK packets.


Are going to be an issue in the future but will be kept aside as an open issue the following points:
- Strings must all be verified to be valid UTF-8
- Must disconnect if string contains NULL
- ClientId MUST actually be UTF-8

We should work on that as soon as possible, but for now the current pull request should be enough


Were already implemented/not impactful:
- ClientIds MAY contain more than 23 encoded bytes
- ClientId MAY be zero bytes long
- ClientId MAY be restricted to alphanumeric chars
- CONNACK has new "session present" flag


Are mostly related to server implementation the following points (and thus ignore for now)
- Clients are allowed to send further Control Packets immediately after sending a CONNECT Packet
- Allow use of WebSocket to initiate connection


This pull request also contains a minor change: the exception raised by the client was not written in the `.mli` file, I added it