### PR TITLE
Encode with correct reserved flags

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,4 +1,4 @@
-version = 0.20.0 
+version = 0.21.0
 profile = conventional
 
 ocaml-version = 4.08.0

--- a/mqtt-client/Mqtt_client.ml
+++ b/mqtt-client/Mqtt_client.ml
@@ -314,17 +314,14 @@ let publish ?(dup = false) ?(qos = Mqtt_core.Atleast_once) ?(retain = false)
     let%lwt () = Lwt_condition.wait cond in
     let expected_ack_pkt = Mqtt_packet.pubcomp id in
     Hashtbl.add client.inflight id (cond, expected_ack_pkt);
-    let pkt_data = Mqtt_packet.Encoder.pubrel ~dup ~qos ~retain id in
+    let pkt_data = Mqtt_packet.Encoder.pubrel id in
     let%lwt () = Lwt_io.write oc pkt_data in
     Lwt_condition.wait cond
 
-let subscribe ?(dup = false) ?(qos = Mqtt_core.Atleast_once) ?(retain = false)
-    topics client =
+let subscribe topics client =
   let _, oc = client.cxn in
   let pkt_id = Mqtt_packet.gen_id () in
-  let subscribe_packet =
-    Mqtt_packet.Encoder.subscribe ~dup ~qos ~retain ~id:pkt_id topics
-  in
+  let subscribe_packet = Mqtt_packet.Encoder.subscribe ~id:pkt_id topics in
   let qos_list = List.map (fun (_, q) -> Ok q) topics in
   let cond = Lwt_condition.create () in
   Hashtbl.add client.inflight pkt_id (cond, Suback (pkt_id, qos_list));

--- a/mqtt-client/Mqtt_client.mli
+++ b/mqtt-client/Mqtt_client.mli
@@ -61,7 +61,9 @@ val connect :
 val disconnect : t -> unit Lwt.t
 (** Disconnects the client from the MQTT broker.
 
-    {[ let%lwt () = Mqtt_client.disconnect client ]} *)
+    {[
+      let%lwt () = Mqtt_client.disconnect client
+    ]} *)
 
 val publish :
   ?dup:bool ->
@@ -78,13 +80,7 @@ val publish :
       let%lwt () = Mqtt_client.publish(~topic="news", payload, client);
     ]} *)
 
-val subscribe :
-  ?dup:bool ->
-  ?qos:qos ->
-  ?retain:bool ->
-  (string * qos) list ->
-  t ->
-  unit Lwt.t
+val subscribe : (string * qos) list -> t -> unit Lwt.t
 (** Subscribes the client to a list of topics.
 
     {[


### PR DESCRIPTION
Currently, the flags stored in the fixed header of each control packet are wrongly encoded:
As advertised in the section `2.2.2` of the specification of MQTT version 3.1.1, most of those flags are reserved and set to 0 (or 2 for the packets `SUBSCRIBE`, `UNSUBSCRIBE` and `PUBREL`). The only packet which has it's own flags is the packet `PUBLISH`.

However we were currently using the flags for the `PUBLISH` packet everywhere instead.
This pull request sets the correct reserved flags for each packet and moves the generation of the flags specific to the packet `PUBLISH` from the function `fixed_header` to `publish`.