### PR TITLE
Overwrite clean session flag if client id is empty

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,4 +1,4 @@
-version = 0.20.0 
+version = 0.21.0
 profile = conventional
 
 ocaml-version = 4.08.0

--- a/mqtt-client/Mqtt_client.ml
+++ b/mqtt-client/Mqtt_client.ml
@@ -314,17 +314,14 @@ let publish ?(dup = false) ?(qos = Mqtt_core.Atleast_once) ?(retain = false)
     let%lwt () = Lwt_condition.wait cond in
     let expected_ack_pkt = Mqtt_packet.pubcomp id in
     Hashtbl.add client.inflight id (cond, expected_ack_pkt);
-    let pkt_data = Mqtt_packet.Encoder.pubrel ~dup ~qos ~retain id in
+    let pkt_data = Mqtt_packet.Encoder.pubrel id in
     let%lwt () = Lwt_io.write oc pkt_data in
     Lwt_condition.wait cond
 
-let subscribe ?(dup = false) ?(qos = Mqtt_core.Atleast_once) ?(retain = false)
-    topics client =
+let subscribe topics client =
   let _, oc = client.cxn in
   let pkt_id = Mqtt_packet.gen_id () in
-  let subscribe_packet =
-    Mqtt_packet.Encoder.subscribe ~dup ~qos ~retain ~id:pkt_id topics
-  in
+  let subscribe_packet = Mqtt_packet.Encoder.subscribe ~id:pkt_id topics in
   let qos_list = List.map (fun (_, q) -> Ok q) topics in
   let cond = Lwt_condition.create () in
   Hashtbl.add client.inflight pkt_id (cond, Suback (pkt_id, qos_list));

--- a/mqtt-client/Mqtt_client.ml
+++ b/mqtt-client/Mqtt_client.ml
@@ -215,7 +215,9 @@ let connect ?(id = "ocaml-mqtt") ?tls_ca ?credentials ?will
     ?(clean_session = true) ?(keep_alive = 30)
     ?(on_message = default_on_message) ?(on_disconnect = default_on_disconnect)
     ?(on_error = default_on_error) ?(port = 1883) hosts =
-  let flags = if clean_session then [ Mqtt_packet.Clean_session ] else [] in
+  let flags =
+    if clean_session || id = "" then [ Mqtt_packet.Clean_session ] else []
+  in
   let cxn_data =
     { Mqtt_packet.clientid = id; credentials; will; flags; keep_alive }
   in

--- a/mqtt-client/Mqtt_client.mli
+++ b/mqtt-client/Mqtt_client.mli
@@ -61,7 +61,9 @@ val connect :
 val disconnect : t -> unit Lwt.t
 (** Disconnects the client from the MQTT broker.
 
-    {[ let%lwt () = Mqtt_client.disconnect client ]} *)
+    {[
+      let%lwt () = Mqtt_client.disconnect client
+    ]} *)
 
 val publish :
   ?dup:bool ->
@@ -78,13 +80,7 @@ val publish :
       let%lwt () = Mqtt_client.publish(~topic="news", payload, client);
     ]} *)
 
-val subscribe :
-  ?dup:bool ->
-  ?qos:qos ->
-  ?retain:bool ->
-  (string * qos) list ->
-  t ->
-  unit Lwt.t
+val subscribe : (string * qos) list -> t -> unit Lwt.t
 (** Subscribes the client to a list of topics.
 
     {[


### PR DESCRIPTION
As specified in the specification (`MQTT 3.1.3-7`), "If the Client supplies a zero-byte ClientId, the Client MUST also set CleanSession to 1".
This pull request adds this verification.

Should be merged after https://github.com/hyper-systems/ocaml-mqtt/pull/14