### PR TITLE
 Reject empty topics in subscription

### DIFF
--- a/mqtt-client/Mqtt_client.ml
+++ b/mqtt-client/Mqtt_client.ml
@@ -321,6 +321,7 @@ let publish ?(dup = false) ?(qos = Mqtt_core.Atleast_once) ?(retain = false)
     Lwt_condition.wait cond
 
 let subscribe topics client =
+  if topics = [] then raise (Invalid_argument "empty topics");
   let _, oc = client.cxn in
   let pkt_id = Mqtt_packet.gen_id () in
   let subscribe_packet = Mqtt_packet.Encoder.subscribe ~id:pkt_id topics in

--- a/mqtt-client/Mqtt_client.mli
+++ b/mqtt-client/Mqtt_client.mli
@@ -81,7 +81,7 @@ val publish :
     ]} *)
 
 val subscribe : (string * qos) list -> t -> unit Lwt.t
-(** Subscribes the client to a list of topics.
+(** Subscribes the client to a non-empty list of topics.
 
     {[
       let topics =


### PR DESCRIPTION
According to the MQTT specification version 3.1.1, statement 3.8.3-3:
```The payload of a SUBSCRIBE packet MUST contain at least one Topic Filter / QoS pair. A SUBSCRIBE packet with no payload is a protocol violation```

This pull requests forces an `Invalid Argument` exception upon calling the subscribe function with an empty list of topics.